### PR TITLE
Fix various export/combine bugs, minor code formatting adjustments, update message strings, update readme

### DIFF
--- a/AssetStudio.PInvoke/DllLoader.cs
+++ b/AssetStudio.PInvoke/DllLoader.cs
@@ -27,7 +27,7 @@ namespace AssetStudio.PInvoke
 
         private static string GetDirectedDllDirectory()
         {
-            var localPath = Process.GetCurrentProcess().MainModule.FileName;
+            var localPath = AppContext.BaseDirectory;
             var localDir = Path.Combine(Path.GetDirectoryName(localPath), "deps");
 
             var subDir = Environment.Is64BitProcess ? "x64" : "x86";

--- a/BitmapUpdate.cs
+++ b/BitmapUpdate.cs
@@ -21,7 +21,6 @@ static class BitmapUpdate
             }
         }
         return String.Empty;
-
     }
 
     public static void ProcessChanges(Image<Bgra32> atlas, Image<Bgra32> replaceImage, Sprite sprite)

--- a/BitmapUpdate.cs
+++ b/BitmapUpdate.cs
@@ -49,7 +49,7 @@ static class BitmapUpdate
                 {
                     rect.Height = 1;
                 }
-                var destRect = new Rectangle(0, 0, rect.Width, rect.Height);
+                var destRect = new Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
                 replaceImage.Mutate((x) => x.Flip(FlipMode.Vertical));
 
                 if (settingsRaw.packed == 1)
@@ -73,7 +73,7 @@ static class BitmapUpdate
                 }
 
                 var point = new Point(destRect.Left, destRect.Top);
-                atlas.Mutate(x => x.DrawImage(replaceImage, point, PixelColorBlendingMode.Add, PixelAlphaCompositionMode.Clear, 1.0f));
+                atlas.Mutate(x => x.DrawImage(replaceImage, point, PixelColorBlendingMode.Add, PixelAlphaCompositionMode.Src, 1.0f));
             }
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -74,8 +74,6 @@ namespace atlastool
 
         public static void StartExtract(string input, string output)
         {
-
-
             Console.WriteLine($"Loading assets from {input}");
             inputPath = input;
             AssetsManager assetManager = LoadAssetManager(input);
@@ -91,7 +89,6 @@ namespace atlastool
 
         public static void SetupPaths(AssetsManager assetsManager, string outputPath)
         {
-
             // find game version first
             gameVersion = GetGameVersion(assetsManager.assetsFileList);
 
@@ -116,11 +113,9 @@ namespace atlastool
 
         public static void WriteSpriteJsonData(ConcurrentBag<SpriteJsonData> spriteData, List<Texture2D> atlasTextures)
         {
-
             using (var fs = File.OpenWrite(jsonOutputPath))
             using (var json = new Utf8JsonWriter(fs, new JsonWriterOptions { Indented = true }))
             {
-
                 json.WriteStartObject();
                 json.WriteString("gameVersion", gameVersion);
                 json.WriteString("unityAssetPath", inputPath);
@@ -128,7 +123,6 @@ namespace atlastool
 
                 foreach (var data in spriteData)
                 {
-
                     json.WriteStartObject();
                     json.WriteString("fileName", data.fileName);
                     json.WriteString("name", data.name);
@@ -145,13 +139,11 @@ namespace atlastool
                 json.WriteEndArray();
 
                 json.WriteEndObject();
-
             }
         }
 
         public static void ExportAtlas(AssetsManager assetManager)
         {
-
             List<Texture2D> atlasTextures = new List<Texture2D>();
 
             Image<Bgra32> atlasImage = null;
@@ -167,7 +159,6 @@ namespace atlastool
                         {
                             if (atlas.m_RenderDataMap.TryGetValue(spr.m_RenderDataKey, out var spriteAtlasData) && spriteAtlasData.texture.TryGet(out var texture))
                             {
-
                                 if (!atlasTextures.Contains(texture))
                                 {
                                     Console.WriteLine($"Found atlas texture {texture.m_Name}");
@@ -194,7 +185,6 @@ namespace atlastool
                     {
                         if (atlas.m_RenderDataMap.TryGetValue(spr.m_RenderDataKey, out var atlasData))
                         {
-
                             var image = SpriteHelper.CutImage(spr, atlasImage, atlasData.textureRect, atlasData.textureRectOffset, atlasData.downscaleMultiplier, atlasData.settingsRaw);
                             string filename = $"{spr.m_Name}_{spr.m_PathID}.png";
                             string filePath = Path.Combine(spriteOutputDir, filename);
@@ -293,7 +283,6 @@ namespace atlastool
 
             foreach ((string fileName, string originalName, string fileHash, int pathID) in imageData)
             {
-
                 string filePath = Path.Combine(spriteDir, fileName);
 
                 //image.Save(filePath, ImageFormat.Png);
@@ -352,76 +341,76 @@ namespace atlastool
                 {
                     case "--input":
                     case "-i":
+                    {
+                        i++;
+                        input = args[i].Trim();
+                        if (!Directory.Exists(input))
                         {
-                            i++;
-                            input = args[i].Trim();
-                            if (!Directory.Exists(input))
-                            {
-                                Console.WriteLine("Error: The specified input path does not exist. Please ensure it has been typed correctly (use quotes if it has spaces).");
-                                return;
-                            }
-                            break;
+                            Console.WriteLine("Error: The specified input path does not exist. Please ensure it has been typed correctly (use quotes if it has spaces).");
+                            return;
                         }
+                        break;
+                    }
 
                     case "--output":
                     case "-o":
+                    {
+                        i++;
+                        output = args[i].Trim();
+                        if (!Directory.Exists(output))
                         {
-                            i++;
-                            output = args[i].Trim();
-                            if (!Directory.Exists(output))
+                            try
                             {
-                                try
-                                {
-                                    Directory.CreateDirectory(output);
-                                }
-                                catch (Exception ex)
-                                {
-                                    Console.WriteLine("Error: Could not create output directory.");
-                                    Console.WriteLine($"Exception info: {ex.Message}");
-                                    return;
-                                }
+                                Directory.CreateDirectory(output);
                             }
-                            break;
+                            catch (Exception ex)
+                            {
+                                Console.WriteLine("Error: Could not create output directory.");
+                                Console.WriteLine($"Exception info: {ex.Message}");
+                                return;
+                            }
                         }
+                        break;
+                    }
 
                     case "--export":
                     case "-x":
-                        {
-                            extract = true;
-                            break;
-                        }
+                    {
+                        extract = true;
+                        break;
+                    }
 
                     case "--combine":
                     case "-c":
-                        {
-                            combine = true;
-                            break;
-                        }
+                    {
+                        combine = true;
+                        break;
+                    }
 
                     case "--help":
                     case "-h":
-                        {
-                            Console.WriteLine("Usage:");
-                            Console.WriteLine("-h        | --help          \tDisplay information about available commands.");
-                            Console.WriteLine("-x        | --export        \tExport the sprite atlas and individual sprites.");
-                            Console.WriteLine("                            \tMust be followed by the -i and (optionally) -o arguments.");
-                            Console.WriteLine("-c        | --combine       \tCombine modified sprites into a new atlas image.");
-                            Console.WriteLine("                            \tMust be followed by the -i argument.");
-                            Console.WriteLine("-i <path> | --input <path>  \tThe input file or folder to extract/combine from.");
-                            Console.WriteLine("                            \tFor extracting, it can be either the data.unity3d file, resources.assets, or Clone Hero_Data folder.");
-                            Console.WriteLine("                            \tFor combining, it should be the folder you want to combine sprites from.");
-                            Console.WriteLine("-o <path> | --output <path> \tThe output directory to extract to.");
-                            Console.WriteLine("                            \tIf unspecified, defaults to atlastool's own folder.");
-                            Console.WriteLine();
-                            Console.WriteLine("Examples:");
-                            Console.WriteLine("- Extracting:");
-                            Console.WriteLine(@"    -x -i C:\Games\Clone Hero\Clone Hero_Data\unity.data3d -o .\extracted");
-                            Console.WriteLine(@"    -x -i %APPDATA%\Clone Hero Launcher\gameFiles\Clone Hero_Data");
-                            Console.WriteLine();
-                            Console.WriteLine("- Combining:");
-                            Console.WriteLine(@"    -c -i .\v.23.2.2");
-                            return;
-                        }
+                    {
+                        Console.WriteLine("Usage:");
+                        Console.WriteLine("-h        | --help          \tDisplay information about available commands.");
+                        Console.WriteLine("-x        | --export        \tExport the sprite atlas and individual sprites.");
+                        Console.WriteLine("                            \tMust be followed by the -i and (optionally) -o arguments.");
+                        Console.WriteLine("-c        | --combine       \tCombine modified sprites into a new atlas image.");
+                        Console.WriteLine("                            \tMust be followed by the -i argument.");
+                        Console.WriteLine("-i <path> | --input <path>  \tThe input file or folder to extract/combine from.");
+                        Console.WriteLine("                            \tFor extracting, it can be either the data.unity3d file, resources.assets, or Clone Hero_Data folder.");
+                        Console.WriteLine("                            \tFor combining, it should be the folder you want to combine sprites from.");
+                        Console.WriteLine("-o <path> | --output <path> \tThe output directory to extract to.");
+                        Console.WriteLine("                            \tIf unspecified, defaults to atlastool's own folder.");
+                        Console.WriteLine();
+                        Console.WriteLine("Examples:");
+                        Console.WriteLine("- Extracting:");
+                        Console.WriteLine(@"    -x -i C:\Games\Clone Hero\Clone Hero_Data\unity.data3d -o .\extracted");
+                        Console.WriteLine(@"    -x -i %APPDATA%\Clone Hero Launcher\gameFiles\Clone Hero_Data");
+                        Console.WriteLine();
+                        Console.WriteLine("- Combining:");
+                        Console.WriteLine(@"    -c -i .\v.23.2.2");
+                        return;
+                    }
                 }
             }
 
@@ -430,6 +419,7 @@ namespace atlastool
                 Console.WriteLine("Error: Cannot extract and combine at the same time.");
                 return;
             }
+
             if (extract && input != string.Empty)
             {
                 StartExtract(input, output);

--- a/Program.cs
+++ b/Program.cs
@@ -216,7 +216,7 @@ namespace atlastool
 
                                 var spriteData = new SpriteJsonData
                                 {
-                                    fileName = filePath,
+                                    fileName = filename,
                                     name = spr.m_Name,
                                     pathID = (int)spr.m_PathID,
                                     hash = hashString

--- a/Program.cs
+++ b/Program.cs
@@ -33,7 +33,6 @@ namespace atlastool
             }
             else
             {
-                Console.WriteLine("Error loading file");
                 return null;
             }
             return assetManager;
@@ -80,6 +79,12 @@ namespace atlastool
             Console.WriteLine($"Loading assets from {input}");
             inputPath = input;
             AssetsManager assetManager = LoadAssetManager(input);
+            if (assetManager == null)
+            {
+                Console.WriteLine("Error: Could not load game data. Please ensure the input path is for the game's data folder or data.unity3d.");
+                return;
+            }
+
             SetupPaths(assetManager, output);
             ExportAtlas(assetManager);
         }
@@ -253,6 +258,12 @@ namespace atlastool
             string assetDataPath = json.ReadString("unityAssetPath");
 
             AssetsManager assetManager = LoadAssetManager(assetDataPath);
+            if (assetManager == null)
+            {
+                Console.WriteLine("Error: Could not load game data from stored data path.");
+                return;
+            }
+
             List<(string fileName, string name, string hash, int pathID)> imageData = new List<(string fileName, string name, string hash, int pathID)>();
             List<string> atlasTextures = new List<string>();
 

--- a/Program.cs
+++ b/Program.cs
@@ -359,8 +359,16 @@ namespace atlastool
                             output = args[i].Trim();
                             if (!Directory.Exists(output))
                             {
-                                Console.WriteLine($"Error: The specified output path does not exist.");
-                                return;
+                                try
+                                {
+                                    Directory.CreateDirectory(output);
+                                }
+                                catch (Exception ex)
+                                {
+                                    Console.WriteLine("Error: Could not create output directory.");
+                                    Console.WriteLine($"Exception info: {ex.Message}");
+                                    return;
+                                }
                             }
                             break;
                         }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -290,6 +290,11 @@ namespace atlastool
 
                 using (var f = File.OpenRead(filePath))
                 {
+                    if (hash == null)
+                    {
+                        hash = SHA1.Create();
+                    }
+
                     hashData = hash.ComputeHash(f);
                 }
                 string hashString = Convert.ToBase64String(hashData);

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -228,7 +228,7 @@ namespace atlastool
                                 };
                                 jsonData.Add(spriteData);
                             }
-                            Console.WriteLine($"fiveFretAtlas Sprite {spr.m_Name} saved");
+                            Console.WriteLine($"Saved atlas sprite {spr.m_Name}");
                         }
                     }
                 });
@@ -238,7 +238,7 @@ namespace atlastool
                     // var image = texture.ConvertToImage(true);
                     atlasImage.Mutate((x) => x.Flip(FlipMode.Vertical));
                     atlasImage.SaveAsPng(imageSavePath);
-                    Console.WriteLine($"Atlas texture2d {texture.m_Name} saved");
+                    Console.WriteLine($"Saved atlas {texture.m_Name}");
                 }
                 WriteSpriteJsonData(jsonData, atlasTextures);
             }
@@ -251,7 +251,7 @@ namespace atlastool
             Utf8JsonReader json = new Utf8JsonReader(jsonText);
             json.ReadObjectStart();
             string gameVersion = json.ReadString("gameVersion");
-            Console.WriteLine($"Found data folder for game version: {gameVersion}");
+            Console.WriteLine($"Found data folder for game version {gameVersion}");
 
             string spriteDir = Path.Combine(inputPath, $"sprites");
 
@@ -357,7 +357,7 @@ namespace atlastool
                             input = args[i].Trim();
                             if (!Directory.Exists(input))
                             {
-                                Console.WriteLine($"Error: The specified input path does not exist.");
+                                Console.WriteLine("Error: The specified input path does not exist. Please ensure it has been typed correctly (use quotes if it has spaces).");
                                 return;
                             }
                             break;
@@ -404,7 +404,7 @@ namespace atlastool
                             Console.WriteLine("Usage:");
                             Console.WriteLine("-h        | --help          \tDisplay information about available commands.");
                             Console.WriteLine("-x        | --export        \tExport the sprite atlas and individual sprites.");
-                            Console.WriteLine("                            \tMust be followed by the -i and (optionally) -o argument.");
+                            Console.WriteLine("                            \tMust be followed by the -i and (optionally) -o arguments.");
                             Console.WriteLine("-c        | --combine       \tCombine modified sprites into a new atlas image.");
                             Console.WriteLine("                            \tMust be followed by the -i argument.");
                             Console.WriteLine("-i <path> | --input <path>  \tThe input file or folder to extract/combine from.");
@@ -414,11 +414,11 @@ namespace atlastool
                             Console.WriteLine("                            \tIf unspecified, defaults to atlastool's own folder.");
                             Console.WriteLine();
                             Console.WriteLine("Examples:");
-                            Console.WriteLine("  Extracting:");
+                            Console.WriteLine("- Extracting:");
                             Console.WriteLine(@"    -x -i C:\Games\Clone Hero\Clone Hero_Data\unity.data3d -o .\extracted");
                             Console.WriteLine(@"    -x -i %APPDATA%\Clone Hero Launcher\gameFiles\Clone Hero_Data");
                             Console.WriteLine();
-                            Console.WriteLine("  Combining:");
+                            Console.WriteLine("- Combining:");
                             Console.WriteLine(@"    -c -i .\v.23.2.2");
                             return;
                         }
@@ -427,7 +427,7 @@ namespace atlastool
 
             if (extract && combine)
             {
-                Console.WriteLine("Error: Cannot extract and combine at the same time");
+                Console.WriteLine("Error: Cannot extract and combine at the same time.");
                 return;
             }
             if (extract && input != string.Empty)
@@ -436,7 +436,7 @@ namespace atlastool
             }
             else if (extract)
             {
-                Console.WriteLine("Error: Export needs an input and output path");
+                Console.WriteLine("Error: Exporting requires an input path to the game's data folder or unity.data3d. Use the -i parameter to specify the path.");
             }
 
             if (combine && input != string.Empty)
@@ -445,7 +445,7 @@ namespace atlastool
             }
             else if (combine)
             {
-                Console.WriteLine("Error: Combine needs an input path");
+                Console.WriteLine("Error: Combining requires an input path to the folder with the sprites to combine. Use the -i parameter to specify the path.");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Clone Hero Texture Atlas Tool
-## A tool for assisting in modifying game textures in Clone Hero
 
-## Usage:
+A tool for assisting in modifying game textures in Clone Hero
+
+## Usage
+
 This program requires you to invoke it and pass commands to it via a command line.
 
-#### Commands:
+### Commands
+
 `-h` / `--help`
 
 Displays information about available commands.
@@ -21,7 +24,8 @@ A new folder named after the game version will be created within the output path
 
 Combines the sprites from the `sprites` folder in the input folder into a new atlas image, which gets placed into the input folder.
 
-#### Examples:
+### Examples
+
 Extracting:
 
 `-x -i C:\Games\Clone Hero\Clone Hero_Data\unity.data3d -o .\extracted`
@@ -32,15 +36,22 @@ Combining:
 
 `-c -i .\v.23.2.2`
 
-#### Note:
-For now, the new atlas will need to be added in using [Unity Asset Bundle Extractor Avalonia](https://github.com/nesrak1/UABEA).
-Use the [latest nightly build](https://nightly.link/nesrak1/UABEA/workflows/dotnet-desktop/master/uabea-windows.zip) instead of the latest release from the Releases page, as the current latest release ("second release") doesn't currently support the version of Unity that CH uses.
-(Be warned that since these are nightly builds, there may be bugs.)
+### Modding the Atlas into the Game
+
+For now, the new atlas will need to be added in using [Unity Asset Bundle Extractor Avalonia](https://github.com/nesrak1/UABEA/releases).
+
+1. Go to File > Open and select the correct data file:
+   - For v.23.2.2 or earlier, load the `data.unity3d` file. For the PTB, load the `resources.assets` file.
+2. Find the texture beginning with `sactx` and select it, then click Plugins and select `Edit texture`.
+3. In the menu, click the Load button to select the new atlas image, and set the texture format setting to RGBA32 to prevent image quality loss.
+4. Click Save.
 
 ## License
+
 This project is licensed under the MIT license. See [license.txt](https://github.com/mdsitton/atlastool/blob/master/license.txt) for details.
 
 See [thirdparty.txt](https://github.com/mdsitton/atlastool/blob/master/thirdparty.txt) for licenses of third-party assets.
 
 ## Acknowledgements
-Perfare's [AssetStudio](https://github.com/Perfare/AssetStudio) for texture extraction
+
+- Perfare's [AssetStudio](https://github.com/Perfare/AssetStudio) for texture extraction

--- a/readme.txt
+++ b/readme.txt
@@ -2,35 +2,38 @@
 A tool for modifying game textures in Clone Hero
 
 
-- Usage:
+Usage:
 This program requires you to invoke it and pass commands to it via a command line.
 
--- Commands:
---- Arguments:
-  -h / --help
+Arguments:
+- -h / --help
   Displays information about available commands.
   
-  -x -i <path1> -o <path2> / --export --input <path1> --output <path2>
+- -x -i <path1> -o <path2> / --export --input <path1> --output <path2>
   Gets the sprite atlas from the input path and exports it and individual sprites to the output path.
   Input directory can be either the data.unity3d file, or the `Clone Hero_Data` folder.
   A new folder named after the game version will be created within the output path. If no path is specified, it defaults to atlastool's folder.
   
-  -c -i <path> / --combine --input <path>
+- -c -i <path> / --combine --input <path>
   Combines the sprites from the `sprites` folder in the input folder into a new atlas image, which gets placed into the input folder.
 
---- Examples:
-  Extracting:
+Examples:
+- Extracting:
     -x -i C:\Games\Clone Hero\Clone Hero_Data\unity.data3d -o .\extracted
     -x -i %APPDATA%\Clone Hero Launcher\gameFiles\Clone Hero_Data
   
-  Combining:
+- Combining:
     -c -i .\v.23.2.2
 
-- Note:
-For now, the new atlas will need to be added in using Unity Asset Bundle Extractor Avalonia: https://github.com/nesrak1/UABEA
-Use the latest nightly build from https://nightly.link/nesrak1/UABEA/workflows/dotnet-desktop/master/uabea-windows.zip instead of the latest release from the Releases page, as the current latest release ("second release") doesn't currently support the version of Unity that CH uses.
-(Be warned that since these are nightly builds, there may be bugs.)
+Note:
+For now, the new atlas will need to be added in using Unity Asset Bundle Extractor Avalonia: https://github.com/nesrak1/UABEA/releases
 
-- License
+1. Go to File > Open and select the correct data file:
+   - For v.23.2.2 or earlier, load the `data.unity3d` file. For the PTB, load the `resources.assets` file.
+2. Find the texture beginning with `sactx` and select it, then click Plugins and select `Edit texture`.
+3. In the menu, click the Load button to select the new atlas image, and set the texture format setting to RGBA32 to prevent image quality loss.
+4. Click Save.
+
+License:
 This program is licensed under the MIT license. See license.txt for details.
 See thirdparty.txt for licenses of third-party assets.


### PR DESCRIPTION
- Fixed a bug in debug mode that caused an exception when trying to pre-load Texture2DDecoder
- Fixed a null reference when combining sprites into a new atlas
- Fixed the fileName field of the sprites.json including folder paths
- Fixed sprite replacement always replacing in the bottom-left corner of the atlas
- Fixed sprite replacement only clearing the existing sprite data
- Change parameter parsing to attempt to create the directory specified in the `-o` parameter instead of rejecting it if it doesn't exist
- Add error handling for when LoadAssetManager returns null
- Remove error message from LoadAssetManager and instead output a different error message wherever the error is being handled
- Rephrase/update most of the message strings
- Adjust some code formatting:
  - Remove some excess line breaks
  - Unindent switch case blocks by 1 tab/set of spaces
  - Add line break between extract+combine error handling and extract error checking block
- Update the readme
  - Adjust formatting
  - Replace note about needing to use UABEA with instructions on how to use it
  - Change UABEA link to link to the releases page